### PR TITLE
Bottom-align AMD logo with title in OF3 header

### DIFF
--- a/life-science/openfold3-ui/templates/index.html
+++ b/life-science/openfold3-ui/templates/index.html
@@ -61,8 +61,8 @@
 
     .panel-header .brand {
       display: flex;
-      align-items: center;
-      gap: 10px;
+      align-items: baseline;
+      gap: 14px;
     }
 
     .panel-header .brand-logo {


### PR DESCRIPTION
## What

Small header touch-up for (follow-up for https://github.com/silogen/ai-samples/pull/5) the OpenFold3 demo UI: bottom-align the AMD logo with the **AIM for OpenFold3** title and add a little more space between them.

## Screenshot

![OpenFold3 UI with bottom-aligned AMD header](https://raw.githubusercontent.com/silogen/ai-samples/pr-assets/amd-logo-touchup/of3-full-after.png)